### PR TITLE
Fix SAR detection for begonia

### DIFF
--- a/app/src/main/java/tk/hack5/treblecheck/MountDetector.kt
+++ b/app/src/main/java/tk/hack5/treblecheck/MountDetector.kt
@@ -41,6 +41,7 @@ object MountDetector {
         return when {
             dynamicPartitions == "true" -> true
             systemRootImage == "true" -> true
+            systemRootImage == "false" -> false
             else -> checkMounts { lines ->
                 lines.any { it.device == "/dev/root" && it.mountpoint == "/" } ||
                         lines.none { it.mountpoint == "/system" && it.type != "tmpfs" && it.device != "none" } ||


### PR DESCRIPTION
begonia (and maybe some other devices) were falsely recognised as being SAR, even though it had set ro.build.system_root_image=false in its build.prop. This commit will make sure it correctly returns false, and to use an A-Only GSI